### PR TITLE
Make collection helpers work even if other transforms are present

### DIFF
--- a/collection-helpers.js
+++ b/collection-helpers.js
@@ -1,13 +1,14 @@
 Mongo.Collection.prototype.helpers = function(helpers) {
   var self = this;
 
-  if (self._transform && ! self._helpers)
-    throw new Meteor.Error("Can't apply helpers to '" +
-      self._name + "' a transform function already exists!");
+  if (!self._helpers) {
+    self._helpers = function Document(doc) {
+      return _.extend(this, doc);
+    };
 
-  if (! self._helpers) {
-    self._helpers = function Document(doc) { return _.extend(this, doc); };
+    var originalTransform = self._transform || function(doc) {return doc};
     self._transform = function(doc) {
+      doc = originalTransform.call(this, doc);
       return new self._helpers(doc);
     };
   }

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "dburles:collection-helpers",
   summary: "Transform your collections with helpers that you define",
-  version: "1.0.4",
+  version: "1.0.5",
   documentation: "README.md",
   git: "https://github.com/dburles/meteor-collection-helpers.git",
 });


### PR DESCRIPTION
We are using TAPi18nDB, which uses transforms, and we also want to continue using collection helpers.
Here's a way of having both. Cheers.